### PR TITLE
Rename plugin template to dk-market

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# **Plugin Name** Plugin
+# **dk-market** Plugin
 
 **Plugin Summary**
 

--- a/app/controllers/dk_market/examples_controller.rb
+++ b/app/controllers/dk_market/examples_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module ::MyPluginModule
+module ::DkMarket
   class ExamplesController < ::ApplicationController
     requires_plugin PLUGIN_NAME
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3,7 +3,7 @@ en:
     admin:
       site_settings:
         categories:
-          TODO_plugin_name: "Plugin Name"
+          dk_market: "DK Market"
   js:
-    discourse_plugin_name:
+    dk_market:
       placeholder: placeholder

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-MyPluginModule::Engine.routes.draw do
+DkMarket::Engine.routes.draw do
   get "/examples" => "examples#index"
   # define routes here
 end
 
-Discourse::Application.routes.draw { mount ::MyPluginModule::Engine, at: "my-plugin" }
+Discourse::Application.routes.draw { mount ::DkMarket::Engine, at: "dk-market" }

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,4 +1,4 @@
-TODO_plugin_name:
-  plugin_name_enabled:
+dk_market:
+  dk_market_enabled:
     default: false
     client: true

--- a/lib/dk_market/engine.rb
+++ b/lib/dk_market/engine.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-module ::MyPluginModule
+module ::DkMarket
   class Engine < ::Rails::Engine
     engine_name PLUGIN_NAME
-    isolate_namespace MyPluginModule
+    isolate_namespace DkMarket
     config.autoload_paths << File.join(config.root, "lib")
     scheduled_job_dir = "#{config.root}/app/jobs/scheduled"
     config.to_prepare do

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# name: discourse-plugin-name
+# name: dk-market
 # about: TODO
 # meta_topic_id: TODO
 # version: 0.0.1
@@ -8,13 +8,13 @@
 # url: TODO
 # required_version: 2.7.0
 
-enabled_site_setting :plugin_name_enabled
+enabled_site_setting :dk_market_enabled
 
-module ::MyPluginModule
-  PLUGIN_NAME = "discourse-plugin-name"
+module ::DkMarket
+  PLUGIN_NAME = "dk-market"
 end
 
-require_relative "lib/my_plugin_module/engine"
+require_relative "lib/dk_market/engine"
 
 after_initialize do
   # Code which should run after Rails has finished booting


### PR DESCRIPTION
## Summary
- rename plugin template structures to dk-market
- update settings, routes, and localization keys for dk-market

## Testing
- `bundle exec rspec` *(fails: bundler: command not found: rspec)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `pnpm exec eslint .` *(fails: Cannot find package '@discourse/lint-configs')*
- `pnpm install` *(fails: Unsupported environment (expected Node >=22, got v20.19.4))*

------
https://chatgpt.com/codex/tasks/task_e_689a9f24542c832c8f47cfcf246624d0