### PR TITLE
Add market system controllers, models, services, routes, and seeds

### DIFF
--- a/app/controllers/market/admin_controller.rb
+++ b/app/controllers/market/admin_controller.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module ::DkMarket
+  class AdminController < ::ApplicationController
+    requires_plugin ::DkMarket::PLUGIN_NAME
+
+    before_action :ensure_logged_in
+    before_action :ensure_staff
+
+    def index
+      render_serialized MarketItem.all, MarketItemSerializer
+    end
+
+    def create
+      item = MarketItem.new(item_params)
+      if item.save
+        render_serialized item, MarketItemSerializer
+      else
+        render_json_error item.errors.full_messages.join("\n")
+      end
+    end
+
+    def update
+      item = MarketItem.find(params[:id])
+      if item.update(item_params)
+        render_serialized item, MarketItemSerializer
+      else
+        render_json_error item.errors.full_messages.join("\n")
+      end
+    end
+
+    def destroy
+      item = MarketItem.find(params[:id])
+      item.destroy
+      render json: success_json
+    end
+
+    private
+
+    def item_params
+      params.require(:market_item).permit(:name, :description, :price, :category, :image_url, :duplicate_policy, :duration)
+    end
+  end
+end

--- a/app/controllers/market/market_controller.rb
+++ b/app/controllers/market/market_controller.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module ::DkMarket
+  class MarketController < ::ApplicationController
+    requires_plugin ::DkMarket::PLUGIN_NAME
+
+    before_action :ensure_logged_in, only: %i[purchase my_item use unuse]
+
+    def index
+      respond_to do |format|
+        format.html { render template: "default/empty" }
+        format.json { render_serialized MarketItem.all, MarketItemSerializer }
+      end
+    end
+
+    def items
+      render_serialized MarketItem.all, MarketItemSerializer
+    end
+
+    def show
+      item = MarketItem.find(params[:id])
+      render_serialized item, MarketItemSerializer
+    end
+
+    def purchase
+      item = MarketItem.find(params[:item_id])
+      result = ::Market::PurchaseService.new(current_user, item).perform
+      if result.success?
+        render json: success_json
+      else
+        render_json_error(result.error)
+      end
+    end
+
+    def my_item
+      inventories = MarketUserInventory.where(user_id: current_user.id)
+      render_serialized inventories, MarketUserInventorySerializer
+    end
+
+    def use
+      inventory = MarketUserInventory.find_by(id: params[:inventory_id], user_id: current_user.id)
+      raise Discourse::NotFound unless inventory
+
+      ::Market::ApplyService.new(current_user, inventory).use
+      render json: success_json
+    end
+
+    def unuse
+      inventory = MarketUserInventory.find_by(id: params[:inventory_id], user_id: current_user.id)
+      raise Discourse::NotFound unless inventory
+
+      ::Market::ApplyService.new(current_user, inventory).unuse
+      render json: success_json
+    end
+  end
+end

--- a/app/models/market_item.rb
+++ b/app/models/market_item.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class MarketItem < ActiveRecord::Base
+  self.table_name = "market_items"
+
+  has_many :market_user_inventories, dependent: :destroy
+  has_many :market_purchase_histories, dependent: :destroy
+
+  validates :name, presence: true
+  validates :duplicate_policy, inclusion: { in: %w[deny extend allow] }, allow_blank: true
+
+  scope :by_category, ->(category) { where(category: category) }
+end

--- a/app/models/market_purchase_history.rb
+++ b/app/models/market_purchase_history.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class MarketPurchaseHistory < ActiveRecord::Base
+  self.table_name = "market_purchase_history"
+
+  belongs_to :user
+  belongs_to :market_item
+
+  validates :user_id, presence: true
+  validates :market_item_id, presence: true
+
+  scope :recent, -> { order(created_at: :desc) }
+end

--- a/app/models/market_user_inventory.rb
+++ b/app/models/market_user_inventory.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class MarketUserInventory < ActiveRecord::Base
+  self.table_name = "market_user_inventory"
+
+  belongs_to :user
+  belongs_to :market_item
+
+  validates :user_id, presence: true
+  validates :market_item_id, presence: true
+
+  scope :in_use, -> { where(in_use: true) }
+  scope :by_user, ->(user) { where(user_id: user.id) }
+end

--- a/app/serializers/market_item_serializer.rb
+++ b/app/serializers/market_item_serializer.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class MarketItemSerializer < ApplicationSerializer
+  attributes :id, :name, :description, :price, :category, :image_url, :duplicate_policy, :duration
+end

--- a/app/serializers/market_user_inventory_serializer.rb
+++ b/app/serializers/market_user_inventory_serializer.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class MarketUserInventorySerializer < ApplicationSerializer
+  attributes :id, :user_id, :in_use, :expires_at
+
+  has_one :market_item, serializer: MarketItemSerializer
+end

--- a/app/services/market/apply_service.rb
+++ b/app/services/market/apply_service.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Market
+  class ApplyService
+    def initialize(user, inventory)
+      @user = user
+      @inventory = inventory
+    end
+
+    def use
+      MarketUserInventory
+        .joins(:market_item)
+        .where(user_id: @user.id, market_items: { category: @inventory.market_item.category })
+        .update_all(in_use: false)
+
+      @inventory.update!(in_use: true)
+    end
+
+    def unuse
+      @inventory.update!(in_use: false)
+    end
+  end
+end

--- a/app/services/market/purchase_service.rb
+++ b/app/services/market/purchase_service.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Market
+  class PurchaseService
+    Result = Struct.new(:success?, :error)
+
+    def initialize(user, item)
+      @user = user
+      @item = item
+    end
+
+    def perform
+      inventory = MarketUserInventory.find_by(user_id: @user.id, market_item_id: @item.id)
+
+      case @item.duplicate_policy
+      when "deny"
+        return Result.new(false, I18n.t("market.errors.already_owned")) if inventory
+        create_inventory
+      when "extend"
+        inventory ? extend_inventory(inventory) : create_inventory
+      else
+        create_inventory
+      end
+
+      MarketPurchaseHistory.create!(user_id: @user.id, market_item_id: @item.id)
+
+      Result.new(true, nil)
+    rescue StandardError => e
+      Result.new(false, e.message)
+    end
+
+    private
+
+    def create_inventory
+      MarketUserInventory.create!(
+        user_id: @user.id,
+        market_item_id: @item.id,
+        in_use: false,
+        expires_at: expiry_time
+      )
+    end
+
+    def extend_inventory(inventory)
+      inventory.update!(expires_at: [inventory.expires_at, Time.zone.now].compact.max + duration)
+    end
+
+    def duration
+      (@item.duration || 0).days
+    end
+
+    def expiry_time
+      @item.duration ? Time.zone.now + duration : nil
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,26 @@
 # frozen_string_literal: true
 
+require_dependency "market/market_controller"
+require_dependency "market/admin_controller"
+
 DkMarket::Engine.routes.draw do
-  get "/examples" => "examples#index"
-  # define routes here
+  get "/" => "market#index"
+  get "/items" => "market#items"
+  get "/items/:id" => "market#show"
+  post "/purchase" => "market#purchase"
+  get "/my_item" => "market#my_item"
+  post "/use" => "market#use"
+  post "/unuse" => "market#unuse"
 end
 
-Discourse::Application.routes.draw { mount ::DkMarket::Engine, at: "dk-market" }
+Discourse::Application.routes.draw do
+  mount ::DkMarket::Engine, at: "/market"
+
+  constraints StaffConstraint.new do
+    get "/admin/market_admin" => "market/admin#index"
+    get "/admin/market_admin/items" => "market/admin#index"
+    post "/admin/market_admin/items" => "market/admin#create"
+    put "/admin/market_admin/items/:id" => "market/admin#update"
+    delete "/admin/market_admin/items/:id" => "market/admin#destroy"
+  end
+end

--- a/db/seed.sql
+++ b/db/seed.sql
@@ -1,0 +1,20 @@
+-- Sample seed data for dk-market plugin
+
+-- Market Items
+INSERT INTO market_items (id, name, description, price, category, image_url, duplicate_policy, duration) VALUES
+  (1, 'Sword', 'A sharp blade', 100, 'weapon', 'https://example.com/sword.png', 'deny', 30),
+  (2, 'Shield', 'Protect yourself', 150, 'armor', 'https://example.com/shield.png', 'extend', 30),
+  (3, 'Potion', 'Heals 50 HP', 50, 'consumable', 'https://example.com/potion.png', 'allow', NULL),
+  (4, 'Helmet', 'Sturdy helmet', 80, 'armor', 'https://example.com/helmet.png', 'deny', 30),
+  (5, 'Boots', 'Run faster', 70, 'gear', 'https://example.com/boots.png', 'allow', NULL);
+
+-- User Inventory for user_id = 1
+INSERT INTO market_user_inventory (id, user_id, market_item_id, in_use, expires_at, created_at, updated_at) VALUES
+  (1, 1, 1, false, NOW() + interval '30 days', NOW(), NOW()),
+  (2, 1, 2, true, NOW() + interval '30 days', NOW(), NOW()),
+  (3, 1, 3, false, NULL, NOW(), NOW());
+
+-- Purchase History for user_id = 1
+INSERT INTO market_purchase_history (id, user_id, market_item_id, created_at, updated_at) VALUES
+  (1, 1, 1, NOW(), NOW()),
+  (2, 1, 2, NOW(), NOW());


### PR DESCRIPTION
## Summary
- implement public and admin market controllers with purchase and inventory management
- add market item, inventory, and purchase history models with serializers
- create purchase and apply services and define market/admin routes

## Testing
- `bundle exec rspec` *(fails: bundler: command not found: rspec)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_689abcd58adc832caeea361eea06b742