### PR TITLE
Add market full-page route

### DIFF
--- a/app/controllers/dk_market/market_controller.rb
+++ b/app/controllers/dk_market/market_controller.rb
@@ -8,7 +8,7 @@ module ::DkMarket
 
     def index
       respond_to do |format|
-        format.html { render template: "default/empty" }
+        format.html { render html: "", layout: true }
         format.json { render_serialized MarketItem.all, MarketItemSerializer }
       end
     end

--- a/assets/javascripts/discourse/controllers/market.js
+++ b/assets/javascripts/discourse/controllers/market.js
@@ -1,0 +1,39 @@
+import Controller from "@ember/controller";
+import { action } from "@ember/object";
+import { tracked } from "@glimmer/tracking";
+import { ajax } from "discourse/lib/ajax";
+
+export default class MarketController extends Controller {
+  @tracked q = "";
+  @tracked sort = "";
+
+  get filtered() {
+    let items = this.model || [];
+
+    if (this.q) {
+      const q = this.q.toLowerCase();
+      items = items.filter((item) => item.name.toLowerCase().includes(q));
+    }
+
+    if (this.sort === "price") {
+      items = items.slice().sort((a, b) => a.price_points - b.price_points);
+    } else if (this.sort === "name") {
+      items = items.slice().sort((a, b) => a.name.localeCompare(b.name));
+    }
+
+    return items;
+  }
+
+  @action
+  updateSort(event) {
+    this.sort = event.target.value;
+  }
+
+  @action
+  purchase(item) {
+    return ajax("/market/purchase", {
+      type: "POST",
+      data: { item_id: item.id },
+    });
+  }
+}

--- a/assets/javascripts/discourse/initializers/dk-market-routes.js
+++ b/assets/javascripts/discourse/initializers/dk-market-routes.js
@@ -1,0 +1,5 @@
+import { apiInitializer } from "discourse/lib/api";
+
+export default apiInitializer("1.61.0", (api) => {
+  api.addFullPage("market", "market");
+});

--- a/assets/javascripts/discourse/routes/market.js
+++ b/assets/javascripts/discourse/routes/market.js
@@ -1,0 +1,8 @@
+import DiscourseRoute from "discourse/routes/discourse";
+import { ajax } from "discourse/lib/ajax";
+
+export default class MarketRoute extends DiscourseRoute {
+  model() {
+    return ajax("/market/items").then((json) => json.items);
+  }
+}

--- a/assets/javascripts/discourse/templates/market.hbs
+++ b/assets/javascripts/discourse/templates/market.hbs
@@ -1,0 +1,30 @@
+<div class="dk-market">
+  <div class="market-header">
+    <h1>Market</h1>
+    <div class="market-controls">
+      <Input @value={{this.q}} placeholder="Search" />
+      <select value={{this.sort}} {{on "change" this.updateSort}}>
+        <option value="">Sort</option>
+        <option value="name">Name</option>
+        <option value="price">Price</option>
+      </select>
+    </div>
+  </div>
+
+  <div class="market-grid">
+    {{#each this.filtered as |item|}}
+      <div class="market-card {{if item.sold_out "sold-out"}}">
+        {{#if item.image}}
+          <img src={{item.image}} alt={{item.name}} />
+        {{/if}}
+        <h3>{{item.name}}</h3>
+        <p class="category">{{item.category}}</p>
+        <p class="price">{{item.price_points}}</p>
+        {{#if item.duration}}
+          <p class="duration">{{item.duration}}</p>
+        {{/if}}
+        <button {{on "click" (fn this.purchase item)}}>구매</button>
+      </div>
+    {{/each}}
+  </div>
+</div>

--- a/assets/stylesheets/common/dk-market.scss
+++ b/assets/stylesheets/common/dk-market.scss
@@ -1,0 +1,38 @@
+.dk-market {
+  padding: 1em;
+}
+
+.market-header {
+  display: flex;
+  flex-direction: column;
+  gap: 1em;
+  margin-bottom: 1em;
+}
+
+.market-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1em;
+}
+
+.market-card {
+  border: 1px solid var(--primary-low);
+  padding: 1em;
+  border-radius: 4px;
+  text-align: center;
+}
+
+.market-card img {
+  max-width: 100%;
+  height: auto;
+  margin-bottom: 0.5em;
+}
+
+.market-card .price {
+  font-weight: bold;
+  color: var(--primary);
+}
+
+.market-card.sold-out {
+  opacity: 0.5;
+}


### PR DESCRIPTION
## Summary
- add initializer registering /market full page route
- implement market route, controller, template, and styles
- render empty layout for server-side /market requests

## Testing
- `pnpm install` *(fails: Unsupported environment (bad pnpm and/or Node.js version))*
- `sudo apt-get update` *(fails: repository InRelease not signed)*
- `bundle install` *(fails: 403 Forbidden)*
- `bundle exec rubocop` *(fails: command not found: rubocop)*
- `bundle exec rspec` *(fails: command not found: rspec)*

------
https://chatgpt.com/codex/tasks/task_e_689acc41008c832c88465702f34d1b25