### PR TITLE
Use Ember router for market page

### DIFF
--- a/app/controllers/dk_market/market_controller.rb
+++ b/app/controllers/dk_market/market_controller.rb
@@ -7,10 +7,7 @@ module ::DkMarket
     before_action :ensure_logged_in, only: %i[purchase my_item use unuse]
 
     def index
-      respond_to do |format|
-        format.html { render html: "", layout: true }
-        format.json { render_serialized MarketItem.all, MarketItemSerializer }
-      end
+      render html: "", layout: true
     end
 
     def items

--- a/assets/javascripts/discourse/initializers/dk-market-routes.js
+++ b/assets/javascripts/discourse/initializers/dk-market-routes.js
@@ -1,5 +1,0 @@
-import { apiInitializer } from "discourse/lib/api";
-
-export default apiInitializer("1.61.0", (api) => {
-  api.addFullPage("market", "market");
-});

--- a/assets/javascripts/discourse/initializers/market-route.js
+++ b/assets/javascripts/discourse/initializers/market-route.js
@@ -1,0 +1,10 @@
+import Router from "discourse/lib/router";
+
+export default {
+  name: "dk-market-route",
+  initialize() {
+    Router.map(function () {
+      this.route("market", { path: "/market" });
+    });
+  },
+};

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,17 +4,17 @@ require_dependency "dk_market/market_controller"
 require_dependency "dk_market/admin_controller"
 
 DkMarket::Engine.routes.draw do
-  get "/" => "market#index"
-  get "/items" => "market#items"
-  get "/items/:id" => "market#show"
-  post "/purchase" => "market#purchase"
-  get "/my_item" => "market#my_item"
-  post "/use" => "market#use"
-  post "/unuse" => "market#unuse"
+  get "/market" => "market#index"
+  get "/market/items" => "market#items"
+  get "/market/items/:id" => "market#show"
+  post "/market/purchase" => "market#purchase"
+  get "/market/my_item" => "market#my_item"
+  post "/market/use" => "market#use"
+  post "/market/unuse" => "market#unuse"
 end
 
-Discourse::Application.routes.draw do
-  mount ::DkMarket::Engine, at: "/market"
+Discourse::Application.routes.append do
+  mount ::DkMarket::Engine, at: "/"
 
   constraints StaffConstraint.new do
     get "/admin/market_admin" => "dk_market/admin#index"


### PR DESCRIPTION
## Summary
- serve `/market` via server-side engine route and use empty layout for Ember app
- map `/market` with Ember Router instead of `api.addFullPage`

## Testing
- `bundle exec rubocop` *(fails: command not found: rubocop)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `pnpm install` *(fails: unsupported environment, Node version < 22)*
- `npx eslint assets/javascripts/discourse/initializers/market-route.js` *(fails: Cannot find package '@discourse/lint-configs')*
- `bundle exec rspec spec` *(fails: command not found: rspec)*

------
https://chatgpt.com/codex/tasks/task_e_689ad231c6bc832cbdeafc29c5a8ba22