### PR TITLE
feat: add my items tab to market

### DIFF
--- a/assets/javascripts/discourse/controllers/market.js
+++ b/assets/javascripts/discourse/controllers/market.js
@@ -1,0 +1,63 @@
+// assets/javascripts/discourse/controllers/market.js
+import Controller from "@ember/controller";
+import { action } from "@ember/object";
+import { ajax } from "discourse/lib/ajax";
+import { tracked } from "@glimmer/tracking";
+
+export default class MarketController extends Controller {
+  @tracked activeTab = "shop";
+  @tracked myItems = null;
+
+  @action
+  async selectTab(tab) {
+    this.activeTab = tab;
+    if (tab === "my" && this.myItems === null) {
+      await this.loadMyItems();
+    }
+  }
+
+  async loadMyItems() {
+    const json = await ajax("/market/my_items");
+    const groups = {};
+
+    (json.items || []).forEach((item) => {
+      const cat = item.category || "기타";
+      if (!groups[cat]) {
+        groups[cat] = [];
+      }
+      groups[cat].push(item);
+    });
+
+    this.myItems = Object.keys(groups)
+      .sort((a, b) => a.localeCompare(b))
+      .map((category) => ({
+        category,
+        items: groups[category].sort((a, b) =>
+          (a.name || "").localeCompare(b.name || "")
+        ),
+      }));
+  }
+
+  @action
+  async toggleUse(item) {
+    if (item.is_used) {
+      await ajax("/market/unuse", {
+        type: "POST",
+        data: { inventory_id: item.inventory_id },
+      });
+      item.is_used = false;
+    } else {
+      await ajax("/market/use", {
+        type: "POST",
+        data: { inventory_id: item.inventory_id },
+      });
+      this.myItems.forEach((group) => {
+        if (group.category === item.category) {
+          group.items.forEach((i) => {
+            i.is_used = i.inventory_id === item.inventory_id;
+          });
+        }
+      });
+    }
+  }
+}

--- a/assets/javascripts/discourse/templates/market.hbs
+++ b/assets/javascripts/discourse/templates/market.hbs
@@ -1,59 +1,121 @@
 {{!-- assets/javascripts/discourse/templates/market.hbs --}}
 <div class="dk-market-page">
-  <h1 class="market-title">Market</h1>
+  <nav class="market-tabs">
+    <button
+      type="button"
+      class="tab {{if (eq this.activeTab 'shop') 'active'}}"
+      {{on "click" (fn this.selectTab 'shop')}}
+    >
+      상점
+    </button>
+    <button
+      type="button"
+      class="tab {{if (eq this.activeTab 'my') 'active'}}"
+      {{on "click" (fn this.selectTab 'my')}}
+    >
+      내 아이템
+    </button>
+  </nav>
 
-  {{#if @model.length}}
-    {{#each @model as |group|}}
-      <section class="market-section">
-        <h2 class="market-section-title">{{group.category}}</h2>
+  {{#if (eq this.activeTab 'shop')}}
+    <h1 class="market-title">Market</h1>
 
-        <div class="market-grid">
-          {{#each group.items as |item|}}
-            <article class="market-card">
-              <div class="market-media">
-                {{#if item.image_url}}
-                  <img class="market-thumb" src={{item.image_url}} alt={{item.name}} loading="lazy" />
-                {{else}}
-                  <img
-                    class="market-thumb"
-                    src={{get-url "/images/no_image.png"}}
-                    alt="No Image"
-                    loading="lazy"
-                  />
-                {{/if}}
-              </div>
+    {{#if @model.length}}
+      {{#each @model as |group|}}
+        <section class="market-section">
+          <h2 class="market-section-title">{{group.category}}</h2>
 
-              <div class="market-info">
-                <h3 class="market-name">{{item.name}}</h3>
-
-                <div class="market-price-row">
-                  <span class="market-price">{{item.price_points}} pts</span>
-                  {{#if item.is_limited_duration}}
-                    <span class="badge badge-duration">기간제 {{item.duration_days}}일</span>
+          <div class="market-grid">
+            {{#each group.items as |item|}}
+              <article class="market-card">
+                <div class="market-media">
+                  {{#if item.image_url}}
+                    <img class="market-thumb" src={{item.image_url}} alt={{item.name}} loading="lazy" />
+                  {{else}}
+                    <img
+                      class="market-thumb"
+                      src={{get-url "/images/no_image.png"}}
+                      alt="No Image"
+                      loading="lazy"
+                    />
                   {{/if}}
                 </div>
 
-                {{#if item.owned}}
-                  <div class="market-sub owned">보유중</div>
-                {{else if item.duplicate_policy}}
-                  <div class="market-sub">중복: {{item.duplicate_policy}}</div>
-                {{/if}}
+                <div class="market-info">
+                  <h3 class="market-name">{{item.name}}</h3>
 
-                <button
-                  class="btn buy-btn"
-                  disabled={{item.owned}}
-                  aria-disabled={{item.owned}}
-                  title={{if item.owned "이미 보유한 아이템입니다" "구매하기"}}
-                >
-                  {{if item.owned "OWNED" "BUY NOW"}}
-                </button>
-              </div>
-            </article>
-          {{/each}}
-        </div>
-      </section>
-    {{/each}}
+                  <div class="market-price-row">
+                    <span class="market-price">{{item.price_points}} pts</span>
+                    {{#if item.is_limited_duration}}
+                      <span class="badge badge-duration">기간제 {{item.duration_days}}일</span>
+                    {{/if}}
+                  </div>
+
+                  {{#if item.owned}}
+                    <div class="market-sub owned">보유중</div>
+                  {{else if item.duplicate_policy}}
+                    <div class="market-sub">중복: {{item.duplicate_policy}}</div>
+                  {{/if}}
+
+                  <button
+                    class="btn buy-btn"
+                    disabled={{item.owned}}
+                    aria-disabled={{item.owned}}
+                    title={{if item.owned "이미 보유한 아이템입니다" "구매하기"}}
+                  >
+                    {{if item.owned "OWNED" "BUY NOW"}}
+                  </button>
+                </div>
+              </article>
+            {{/each}}
+          </div>
+        </section>
+      {{/each}}
+    {{else}}
+      <p class="market-empty">활성화된 아이템이 없습니다.</p>
+    {{/if}}
   {{else}}
-    <p class="market-empty">활성화된 아이템이 없습니다.</p>
+    <h1 class="market-title">My Items</h1>
+
+    {{#if this.myItems}}
+      {{#if this.myItems.length}}
+        {{#each this.myItems as |group|}}
+          <section class="market-section">
+            <h2 class="market-section-title">{{group.category}}</h2>
+
+            <div class="market-grid">
+              {{#each group.items as |item|}}
+                <article class="market-card">
+                  <div class="market-media">
+                    {{#if item.image_url}}
+                      <img class="market-thumb" src={{item.image_url}} alt={{item.name}} loading="lazy" />
+                    {{else}}
+                      <img
+                        class="market-thumb"
+                        src={{get-url "/images/no_image.png"}}
+                        alt="No Image"
+                        loading="lazy"
+                      />
+                    {{/if}}
+                  </div>
+
+                  <div class="market-info">
+                    <h3 class="market-name">{{item.name}}</h3>
+
+                    <button class="btn use-btn" {{on "click" (fn this.toggleUse item)}}>
+                      {{if item.is_used "UNEQUIP" "EQUIP"}}
+                    </button>
+                  </div>
+                </article>
+              {{/each}}
+            </div>
+          </section>
+        {{/each}}
+      {{else}}
+        <p class="market-empty">보유한 아이템이 없습니다.</p>
+      {{/if}}
+    {{else}}
+      <p class="market-empty">Loading...</p>
+    {{/if}}
   {{/if}}
 </div>

--- a/assets/stylesheets/common/dk-market.scss
+++ b/assets/stylesheets/common/dk-market.scss
@@ -103,4 +103,25 @@
   }
 
   .market-empty { color: var(--primary-medium, #6b7280); }
+
+  .market-tabs {
+    display: flex;
+    gap: 8px;
+    border-bottom: 1px solid var(--primary-low, #f3f4f6);
+    margin-bottom: 1rem;
+
+    .tab {
+      padding: 8px 16px;
+      background: transparent;
+      border: none;
+      cursor: pointer;
+      font-weight: 600;
+      color: var(--primary-medium, #6b7280);
+
+      &.active {
+        color: var(--primary, #000);
+        border-bottom: 2px solid var(--primary, #000);
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- add tabs to switch between market and user inventory views
- load and manage user inventory items in a new controller
- style market tabs

## Testing
- `pnpm exec eslint assets/javascripts/discourse/controllers/market.js` (fails: Cannot find package '@discourse/lint-configs')
- `pnpm exec ember-template-lint assets/javascripts/discourse/templates/market.hbs` (fails: Command "ember-template-lint" not found)
- `pnpm exec stylelint assets/stylesheets/common/dk-market.scss` (fails: Command "stylelint" not found)
- `bundle exec rspec` (fails: command not found, suggests `bundle install`)


------
https://chatgpt.com/codex/tasks/task_e_689be53fc108832cb3f64c4b9c597a27