### PR TITLE
chore: add debug logs for my items view

### DIFF
--- a/assets/javascripts/discourse/components/market-my.js
+++ b/assets/javascripts/discourse/components/market-my.js
@@ -32,7 +32,10 @@ export default class MarketMyComponent extends Component {
     this.isLoading = true;
     try {
       const json = await ajax("/market/my_items");
-      this.items = this._groupByCategory(json?.items ?? []);
+      console.log("[market-my] fetched items", json?.items);
+      const grouped = this._groupByCategory(json?.items ?? []);
+      console.log("[market-my] grouped items", grouped);
+      this.items = grouped;
     } catch (e) {
       popupAjaxError(e);
       this.items = [];
@@ -44,6 +47,7 @@ export default class MarketMyComponent extends Component {
   _groupByCategory(items = []) {
     const groups = {};
     for (const item of items) {
+      console.log("[market-my] processing item", item);
       const cat = item?.category || "기타";
       (groups[cat] ||= []).push(item);
     }

--- a/assets/javascripts/discourse/routes/market-my.js
+++ b/assets/javascripts/discourse/routes/market-my.js
@@ -5,9 +5,11 @@ import { ajax } from "discourse/lib/ajax";
 export default class MarketMyRoute extends DiscourseRoute {
   async model() {
     const json = await ajax("/market/my_items");
+    console.log("[market-my route] fetched items", json.items);
     const groups = {};
 
     (json.items || []).forEach((item) => {
+      console.log("[market-my route] processing item", item);
       const cat = item.category || "기타";
       if (!groups[cat]) {
         groups[cat] = [];
@@ -15,7 +17,7 @@ export default class MarketMyRoute extends DiscourseRoute {
       groups[cat].push(item);
     });
 
-    return Object.keys(groups)
+    const result = Object.keys(groups)
       .sort((a, b) => a.localeCompare(b))
       .map((category) => ({
         category,
@@ -23,5 +25,7 @@ export default class MarketMyRoute extends DiscourseRoute {
           (a.name || "").localeCompare(b.name || "")
         ),
       }));
+    console.log("[market-my route] grouped items", result);
+    return result;
   }
 }


### PR DESCRIPTION
## Summary
- log raw and grouped data when loading "my items"
- log each item handled during grouping in the Ember route and component

## Testing
- `pnpm lint` *(fails: Unsupported environment (bad pnpm and/or Node.js version))*
- `bundle exec rubocop` *(fails: command not found: rubocop)*

------
https://chatgpt.com/codex/tasks/task_e_689c58d19f88832c87e2ef8ef74f7f86