### PR TITLE
Implement market purchase flow and item timers

### DIFF
--- a/app/services/market/purchase_service.rb
+++ b/app/services/market/purchase_service.rb
@@ -2,7 +2,7 @@
 
 module Market
   class PurchaseService
-    Result = Struct.new(:success?, :error)
+    Result = Struct.new(:success?, :error, :before_points, :after_points)
 
     def initialize(user, item)
       @user = user
@@ -10,30 +10,52 @@ module Market
     end
 
     def perform
-      inventory = MarketUserInventory.find_by(user_id: @user.id, item_id: @item.id)
+      ActiveRecord::Base.transaction do
+        inventory =
+          MarketUserInventory.active_current.find_by(
+            user_id: @user.id,
+            item_id: @item.id,
+          )
 
-      case @item.duplicate_policy
-      when "deny"
-        return Result.new(false, I18n.t("market.errors.already_owned")) if inventory
-        create_inventory
-      when "extend"
-        inventory ? extend_inventory(inventory) : create_inventory
-      else
-        create_inventory
+        before_points =
+          DB.query_single(
+            "SELECT COALESCE(point,0) FROM gamification_scores WHERE user_id = ?",
+            @user.id,
+          ).first.to_i
+        if before_points < @item.price_points
+          return Result.new(false, I18n.t("market.errors.not_enough_points"))
+        end
+        after_points = before_points - @item.price_points
+        DB.exec(
+          "UPDATE gamification_scores SET point = ? WHERE user_id = ?",
+          after_points,
+          @user.id,
+        )
+
+        case @item.duplicate_policy
+        when "deny"
+          return Result.new(false, I18n.t("market.errors.already_owned")) if inventory
+          inventory = create_inventory
+        when "extend"
+          inventory = inventory ? extend_inventory(inventory) : create_inventory
+        else
+          inventory = create_inventory
+        end
+
+        MarketPurchaseHistory.create!(
+          user_id: @user.id,
+          item_id: @item.id,
+          quantity: 1,
+          price_points: @item.price_points,
+          status: "completed",
+          payment_type: "usable_points",
+          before_points: before_points,
+          after_points: after_points,
+          market_snapshot_json: @item.as_json,
+        )
+
+        Result.new(true, nil, before_points, after_points)
       end
-
-      MarketPurchaseHistory.create!(
-        user_id: @user.id,
-        item_id: @item.id,
-        quantity: 1,
-        price_points: @item.price_points,
-        status: "completed",
-        payment_type: "usable_points",
-        before_points: 0,
-        after_points: 0,
-      )
-
-      Result.new(true, nil)
     rescue StandardError => e
       Result.new(false, e.message)
     end
@@ -50,9 +72,12 @@ module Market
     end
 
     def extend_inventory(inventory)
-      return unless @item.is_limited_duration
+      return inventory unless @item.is_limited_duration
 
-      inventory.update!(expires_at: [inventory.expires_at, Time.zone.now].compact.max + duration)
+      inventory.update!(
+        expires_at: [inventory.expires_at, Time.zone.now].compact.max + duration,
+      )
+      inventory
     end
 
     def duration

--- a/assets/javascripts/discourse/components/market-item.js
+++ b/assets/javascripts/discourse/components/market-item.js
@@ -3,6 +3,7 @@ import { action } from "@ember/object";
 import { set } from "@ember/object";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
+import bootbox from "bootbox";
 
 export default class MarketItemComponent extends Component {
   @action
@@ -11,15 +12,23 @@ export default class MarketItemComponent extends Component {
       return;
     }
     set(item, "isCooldown", true);
-    try {
-      await ajax("/market/buy", { type: "POST", data: { item_id: item.id } });
-      set(item, "owned", true);
-    } catch (e) {
-      popupAjaxError(e);
-    } finally {
-      setTimeout(() => {
-        set(item, "isCooldown", false);
-      }, 3000);
+      try {
+        const result = await ajax("/market/purchase", {
+          type: "POST",
+          data: { item_id: item.id },
+        });
+        set(item, "owned", true);
+        bootbox.alert(`${result.before_points} > ${result.after_points}`);
+      } catch (e) {
+        if (e.jqXHR?.responseJSON?.error) {
+          bootbox.alert(e.jqXHR.responseJSON.error);
+        } else {
+          popupAjaxError(e);
+        }
+      } finally {
+        setTimeout(() => {
+          set(item, "isCooldown", false);
+        }, 3000);
+      }
     }
   }
-}

--- a/assets/javascripts/discourse/components/market-my.js
+++ b/assets/javascripts/discourse/components/market-my.js
@@ -33,6 +33,21 @@ export default class MarketMyComponent extends Component {
     }));
   }
 
+  _calcRemaining(expiresAt) {
+    if (!expiresAt) {
+      return null;
+    }
+    const diff = new Date(expiresAt) - new Date();
+    if (diff <= 0) {
+      return null;
+    }
+    const dayMs = 1000 * 60 * 60 * 24;
+    const hourMs = 1000 * 60 * 60;
+    const days = Math.floor(diff / dayMs);
+    const hours = Math.floor((diff % dayMs) / hourMs);
+    return `${String(days).padStart(2, "0")}일${String(hours).padStart(2, "0")}시간`;
+  }
+
   async loadItems() {
     this.isLoading = true;
     try {
@@ -40,6 +55,7 @@ export default class MarketMyComponent extends Component {
       const byCat = {};
       (json?.items || []).forEach((it) => {
         const c = it?.category || "기타";
+        it.remaining_time = this._calcRemaining(it.expires_at);
         (byCat[c] ||= []).push(it);
       });
       const grouped = Object.keys(byCat)

--- a/assets/javascripts/discourse/templates/components/market-my.hbs
+++ b/assets/javascripts/discourse/templates/components/market-my.hbs
@@ -42,7 +42,11 @@
 
               <div class="market-info">
                 <h3 class="market-name">{{item.name}}</h3>
-
+                {{#if item.remaining_time}}
+                  <div class="market-price-row">
+                    <span class="badge badge-duration">{{item.remaining_time}}</span>
+                  </div>
+                {{/if}}
                 <button
                   class="btn use-btn"
                   disabled={{if (eq this.togglingId item.inventory_id) true item._cooldown}}

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,1 +1,5 @@
 en:
+  market:
+    errors:
+      already_owned: "Item already owned."
+      not_enough_points: "Not enough points."


### PR DESCRIPTION
## Summary
- show remaining time on owned market items
- add point deduction and history records when purchasing
- display point balance popups on purchase

## Testing
- `bundle exec rubocop` *(fails: command not found)*
- `pnpm install` *(fails: Node version unsupported)*
- `pnpm exec eslint .` *(fails: missing @discourse/lint-configs)*
- `pnpm exec ember-template-lint .` *(fails: command not found)*
- `pnpm exec stylelint "**/*.{scss,css}"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d633aef98832ca346d105e97935cb