### PR TITLE
refactor: use global Bootbox instance

### DIFF
--- a/assets/javascripts/discourse/components/market-item.js
+++ b/assets/javascripts/discourse/components/market-item.js
@@ -3,7 +3,6 @@ import { action } from "@ember/object";
 import { set } from "@ember/object";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
-import bootbox from "bootbox";
 
 export default class MarketItemComponent extends Component {
   @action
@@ -12,23 +11,23 @@ export default class MarketItemComponent extends Component {
       return;
     }
     set(item, "isCooldown", true);
-      try {
-        const result = await ajax("/market/purchase", {
-          type: "POST",
-          data: { item_id: item.id },
-        });
-        set(item, "owned", true);
-        bootbox.alert(`${result.before_points} > ${result.after_points}`);
-      } catch (e) {
-        if (e.jqXHR?.responseJSON?.error) {
-          bootbox.alert(e.jqXHR.responseJSON.error);
-        } else {
-          popupAjaxError(e);
-        }
-      } finally {
-        setTimeout(() => {
-          set(item, "isCooldown", false);
-        }, 3000);
+    try {
+      const result = await ajax("/market/purchase", {
+        type: "POST",
+        data: { item_id: item.id },
+      });
+      set(item, "owned", true);
+      window.bootbox.alert(`${result.before_points} > ${result.after_points}`);
+    } catch (e) {
+      if (e.jqXHR?.responseJSON?.error) {
+        window.bootbox.alert(e.jqXHR.responseJSON.error);
+      } else {
+        popupAjaxError(e);
       }
+    } finally {
+      setTimeout(() => {
+        set(item, "isCooldown", false);
+      }, 3000);
     }
   }
+}


### PR DESCRIPTION
## Summary
- switch from module import to global `window.bootbox` for alerts

## Testing
- `pnpm install` *(fails: Unsupported environment, Node version >=22 required)*
- `pnpm dlx eslint@9.27.0 assets/javascripts/discourse/components/market-item.js` *(fails: 403 fetching from registry)*

------
https://chatgpt.com/codex/tasks/task_e_689d6a56df3c832cb03d165e1d6cf9f5