### PR TITLE
feat: add purchase confirmation with points

### DIFF
--- a/assets/javascripts/discourse/components/market-item.js
+++ b/assets/javascripts/discourse/components/market-item.js
@@ -12,22 +12,45 @@ export default class MarketItemComponent extends Component {
     }
     set(item, "isCooldown", true);
     try {
-      const result = await ajax("/market/purchase", {
-        type: "POST",
+      const info = await ajax("/market/purchase_info", {
+        type: "GET",
         data: { item_id: item.id },
       });
-      set(item, "owned", true);
-      window.bootbox.alert(`${result.before_points} > ${result.after_points}`);
+      const duration = info.duration_days
+        ? `${info.duration_days}일동안`
+        : "무제한으로";
+      const message = `보유포인트 ${info.points} 사용포인트 ${info.price_points} ${duration} 사용 가능합니다. 정말 구매하시겠습니까?`;
+      window.bootbox.confirm(message, async (result) => {
+        if (result) {
+          try {
+            const purchaseResult = await ajax("/market/purchase", {
+              type: "POST",
+              data: { item_id: item.id },
+            });
+            set(item, "owned", true);
+            window.bootbox.alert(`${purchaseResult.before_points} > ${purchaseResult.after_points}`);
+          } catch (e) {
+            if (e.jqXHR?.responseJSON?.error) {
+              window.bootbox.alert(e.jqXHR.responseJSON.error);
+            } else {
+              popupAjaxError(e);
+            }
+          } finally {
+            setTimeout(() => {
+              set(item, "isCooldown", false);
+            }, 3000);
+          }
+        } else {
+          set(item, "isCooldown", false);
+        }
+      });
     } catch (e) {
       if (e.jqXHR?.responseJSON?.error) {
         window.bootbox.alert(e.jqXHR.responseJSON.error);
       } else {
         popupAjaxError(e);
       }
-    } finally {
-      setTimeout(() => {
-        set(item, "isCooldown", false);
-      }, 3000);
+      set(item, "isCooldown", false);
     }
   }
 }

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3,3 +3,8 @@ en:
     errors:
       already_owned: "Item already owned."
       not_enough_points: "Not enough points."
+ko:
+  market:
+    errors:
+      already_owned: "이미 보유한 아이템입니다."
+      not_enough_points: "포인트가 부족합니다."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ DkMarket::Engine.routes.draw do
   root to: "market#index"
   get "/items" => "market#items"
   get "/items/:id" => "market#show"
+  get "/purchase_info" => "market#purchase_info"
   post "/purchase" => "market#purchase"
   get "/my_items" => "market#my_items"
   post "/use" => "market#use"


### PR DESCRIPTION
## Summary
- add Korean translations for server-side market errors
- show confirmation dialog with points/duration before item purchase
- provide purchase info endpoint for client-side checks

## Testing
- `bundle exec rubocop` *(fails: command not found, bundle install 403 Forbidden)*
- `pnpm eslint assets/javascripts/discourse/components/market-item.js` *(fails: unsupported engine, requires Node >=22)*
- `bundle exec rspec` *(fails: command not found, gems not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689d9135bc38832cb96c910e33bfad2a