### PR TITLE
feat: apply global cooldown to item actions

### DIFF
--- a/assets/javascripts/discourse/templates/components/market-my.hbs
+++ b/assets/javascripts/discourse/templates/components/market-my.hbs
@@ -49,8 +49,8 @@
                 {{/if}}
                 <button
                   class="btn use-btn"
-                  disabled={{if (eq this.togglingId item.inventory_id) true item._cooldown}}
-                  aria-disabled={{if (eq this.togglingId item.inventory_id) true item._cooldown}}
+                  disabled={{or (eq this.togglingId item.inventory_id) this.itemCooling}}
+                  aria-disabled={{or (eq this.togglingId item.inventory_id) this.itemCooling}}
                   title={{if (eq this.togglingId item.inventory_id) "처리 중..." (if item.is_used "해제" "장착")}}
                   {{on "click" (fn this.toggleUse item)}}
                 >


### PR DESCRIPTION
## Summary
- replace per-item cooldown tracking with global `itemCooling`
- disable all item action buttons during cooldown period

## Testing
- `pnpm install` (fails: Unsupported engine)
- `pnpm install --engine-strict=false` (fails: GET https://registry.npmjs.org/@discourse/lint-configs/-/lint-configs-2.21.0.tgz: Forbidden)
- `pnpm exec eslint assets/javascripts/discourse/components/market-my.js` (fails: Cannot find package '@discourse/lint-configs')
- `pnpm test` (fails: Unsupported engine)


------
https://chatgpt.com/codex/tasks/task_e_68a50e497504832c9bd8efb3f59edf87