### PR TITLE
Expose active market effects in user serializer

### DIFF
--- a/assets/javascripts/discourse/initializers/market-effects.js
+++ b/assets/javascripts/discourse/initializers/market-effects.js
@@ -1,0 +1,47 @@
+import { withPluginApi } from "discourse/lib/plugin-api";
+
+export default {
+  name: "market-effects",
+
+  initialize() {
+    withPluginApi("1.8.0", (api) => {
+      function applyEffects(container, user, selector) {
+        const target = container.querySelector(selector);
+        if (!target) {
+          return;
+        }
+
+        user.market_effects.forEach((effect) => {
+          target.classList.add(`market-effect-${effect.category}`);
+        });
+      }
+
+      api.decorateWidget("poster-name:after", (dec) => {
+        const user = dec.attrs.user;
+        if (!user || !user.market_effects?.length) {
+          return;
+        }
+
+        console.log("market_effects", user.market_effects);
+
+        dec.afterRender(() => {
+          applyEffects(dec.widget.element, user, "span.username");
+        });
+      });
+
+      api.decorateWidget("user-avatar:after", (dec) => {
+        const user = dec.attrs.user;
+        if (!user || !user.market_effects?.length) {
+          return;
+        }
+
+        console.log("market_effects", user.market_effects);
+
+        dec.afterRender(() => {
+          applyEffects(dec.widget.element, user, "img");
+        });
+      });
+    });
+  },
+};
+

--- a/assets/stylesheets/common/dk-market.scss
+++ b/assets/stylesheets/common/dk-market.scss
@@ -145,3 +145,13 @@
     }
   }
 }
+
+// Market effect styling
+.username.market-effect-nametag_effect {
+  text-shadow: 0 0 6px var(--tertiary);
+}
+
+img.market-effect-profile_effect {
+  box-shadow: 0 0 6px var(--tertiary);
+  border-radius: 50%;
+}

--- a/plugin.rb
+++ b/plugin.rb
@@ -18,5 +18,26 @@ require_relative "lib/dk_market/engine"
 register_asset "stylesheets/common/dk-market.scss"
 
 after_initialize do
-  # Code which should run after Rails has finished booting
+  add_to_serializer(:basic_user, :market_effects) do
+    inventories =
+      MarketUserInventory
+        .active_current
+        .in_use
+        .by_user(object)
+        .includes(:market_item)
+
+    items = inventories.map do |inv|
+      item = inv.market_item
+      item.inventory_id = inv.id
+      item.expires_at = inv.expires_at
+      item.is_used = true
+      item
+    end
+
+    items.map { |it| MarketItemSerializer.new(it, scope: scope, root: false).as_json }
+  end
+
+  add_to_serializer(:basic_user, :include_market_effects?) do
+    SiteSetting.dk_market_enabled
+  end
 end

--- a/spec/serializers/market_effects_serializer_spec.rb
+++ b/spec/serializers/market_effects_serializer_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "BasicUser serializer market effects" do
+  let(:user) { Fabricate(:user) }
+
+  let!(:item) do
+    MarketItem.create!(
+      name: "Glowy",
+      category: "nametag_effect",
+      price_points: 1,
+      duplicate_policy: "allow",
+    )
+  end
+
+  let!(:inventory) do
+    MarketUserInventory.create!(
+      user_id: user.id,
+      item_id: item.id,
+      is_used: true,
+      is_active: true,
+    )
+  end
+
+  before { SiteSetting.dk_market_enabled = true }
+
+  it "returns equipped effects" do
+    json = BasicUserSerializer.new(user, scope: Guardian.new(user), root: false).as_json
+
+    expect(json[:market_effects]).to contain_exactly(
+      hash_including(id: item.id, name: "Glowy", category: "nametag_effect"),
+    )
+  end
+end


### PR DESCRIPTION
## Summary
- expose equipped market items as `market_effects` on `BasicUserSerializer`
- test that the new serializer data returns active effects

## Testing
- `bundle exec rubocop` *(fails: command not found: rubocop)*
- `bundle exec rspec spec/serializers/market_effects_serializer_spec.rb` *(fails: command not found: rspec)*

------
https://chatgpt.com/codex/tasks/task_e_68a51a8c2244832c9639844bdfa95980