### PR TITLE
Expose level_name in market item retrieval

### DIFF
--- a/app/controllers/dk_market/market_controller.rb
+++ b/app/controllers/dk_market/market_controller.rb
@@ -17,7 +17,9 @@ module ::DkMarket
           .joins(
             "LEFT JOIN gamification_level_infos ON gamification_level_infos.level = market_items.min_level",
           )
-          .select("market_items.*, gamification_level_infos.image_url AS level_image_url")
+          .select(
+            "market_items.*, gamification_level_infos.image_url AS level_image_url, gamification_level_infos.name AS level_name",
+          )
           .order(:min_level, :category, :name)
           .to_a
 

--- a/app/models/market_item.rb
+++ b/app/models/market_item.rb
@@ -14,5 +14,5 @@ class MarketItem < ActiveRecord::Base
 
   scope :by_category, ->(category) { where(category: category) }
 
-  attr_accessor :owned, :inventory_id, :expires_at, :is_used, :level_image_url
+  attr_accessor :owned, :inventory_id, :expires_at, :is_used, :level_image_url, :level_name
 end

--- a/app/serializers/market_item_serializer.rb
+++ b/app/serializers/market_item_serializer.rb
@@ -4,5 +4,6 @@ class MarketItemSerializer < ApplicationSerializer
   attributes :id, :name, :category, :price_points,
              :is_limited_duration, :duration_days, :duplicate_policy,
              :image_url, :metadata_json, :is_active, :min_level,
-             :owned, :inventory_id, :expires_at, :is_used, :level_image_url
+             :owned, :inventory_id, :expires_at, :is_used, :level_image_url,
+             :level_name
 end


### PR DESCRIPTION
## Summary
- Include `level_name` when selecting market items and expose it through the serializer
- Track `level_name` on `MarketItem` models for template use

## Testing
- `bundle exec rspec` *(fails: bundler: command not found: rspec)*
- `bundle install` *(fails: 403 "Forbidden" from rubygems.org)*

------
https://chatgpt.com/codex/tasks/task_e_68a69b060db8832c8f057003b3c1a3de