### PR TITLE
Fix missing level attributes for market items

### DIFF
--- a/app/models/market_item.rb
+++ b/app/models/market_item.rb
@@ -14,5 +14,5 @@ class MarketItem < ActiveRecord::Base
 
   scope :by_category, ->(category) { where(category: category) }
 
-  attr_accessor :owned, :inventory_id, :expires_at, :is_used, :level_image_url, :level_name
+  attr_accessor :owned, :inventory_id, :expires_at, :is_used
 end


### PR DESCRIPTION
## Summary
- ensure MarketItem can expose joined level_image_url and level_name

## Testing
- `pnpm lint` *(fails: Unsupported environment (bad pnpm and/or Node.js version))*
- `bundle exec rubocop` *(fails: bundler: command not found: rubocop)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a6a06cb2bc832c8bf896b2bfe78eb0