### PR TITLE
Fix level info join for market items

### DIFF
--- a/app/controllers/dk_market/market_controller.rb
+++ b/app/controllers/dk_market/market_controller.rb
@@ -18,7 +18,7 @@ module ::DkMarket
             "LEFT JOIN gamification_level_infos ON gamification_level_infos.level = market_items.min_level",
           )
           .select(
-            "market_items.*, gamification_level_infos.image_url AS level_image_url, gamification_level_infos.name AS level_name",
+            "market_items.*, gamification_level_infos.level_image_url, gamification_level_infos.level_name",
           )
           .order(:min_level, :category, :name)
           .to_a


### PR DESCRIPTION
## Summary
- join market items to gamification levels via level field
- select level image and name so serializer can expose them

## Testing
- `bundle exec rspec` *(fails: bundler: command not found: rspec)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a6a77d9e80832cb1d2380867567869