### PR TITLE
Fix level data retrieval in items query

### DIFF
--- a/app/controllers/dk_market/market_controller.rb
+++ b/app/controllers/dk_market/market_controller.rb
@@ -18,7 +18,7 @@ module ::DkMarket
             "LEFT JOIN gamification_level_infos ON gamification_level_infos.level = market_items.min_level",
           )
           .select(
-            "market_items.*, gamification_level_infos.level_image_url, gamification_level_infos.level_name",
+            "market_items.*, gamification_level_infos.image_url AS level_image_url, gamification_level_infos.name AS level_name",
           )
           .order(:min_level, :category, :name)
           .to_a


### PR DESCRIPTION
## Summary
- correctly select level image and name columns when loading items

## Testing
- `bundle exec rubocop` *(fails: bundler: command not found: rubocop)*
- `bundle exec rspec` *(fails: bundler: command not found: rspec)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c3da0bc8832cacb3c69ea8abfb8c