### PR TITLE
Add level info serialization

### DIFF
--- a/app/models/market_item.rb
+++ b/app/models/market_item.rb
@@ -14,5 +14,6 @@ class MarketItem < ActiveRecord::Base
 
   scope :by_category, ->(category) { where(category: category) }
 
-  attr_accessor :owned, :inventory_id, :expires_at, :is_used
+  attr_accessor :owned, :inventory_id, :expires_at, :is_used,
+                :level_image_url, :level_name
 end

--- a/assets/javascripts/discourse/templates/components/market-item.hbs
+++ b/assets/javascripts/discourse/templates/components/market-item.hbs
@@ -61,7 +61,10 @@
                   {{#if locked}}
                     <div class="market-lock-overlay">
                       {{#if item.level_image_url}}
-                        <img src={{item.level_image_url}} alt="필요 레벨" />
+                        <img src={{item.level_image_url}} alt={{item.level_name}} />
+                      {{/if}}
+                      {{#if item.level_name}}
+                        <span class="market-lock-level-name">{{item.level_name}}</span>
                       {{/if}}
                     </div>
                   {{/if}}

--- a/assets/stylesheets/common/dk-market.scss
+++ b/assets/stylesheets/common/dk-market.scss
@@ -81,6 +81,15 @@
         left: 50%;
         transform: translate(-50%, -50%);
         z-index: 1;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
+
+        .market-lock-level-name {
+          margin-top: 4px;
+          font-weight: 600;
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- expose level image and name for market items
- display required level image and name on locked items
- style lock overlay to show level text

## Testing
- `pnpm lint` *(fails: unsupported Node.js version)*
- `bundle exec rake spec` *(fails: missing gems)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c6e82790832ca4fcd61a8ee92a50